### PR TITLE
Feat: migrate multiple tokens

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: CI Tests
 on: [push, pull_request, pull_request_target]
 
 env:
-  PROTOSTAR_VERSION: 0.9.1
+  PROTOSTAR_VERSION: 0.9.2
 
 jobs:
   protostar-tests:

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,5 +1,5 @@
 [project]
-protostar-version = "0.9.1"
+protostar-version = "0.9.2"
 lib-path = "lib"
 cairo-path = [
     "./lib/cairo_contracts/src",

--- a/src/migrator/IMigrator.cairo
+++ b/src/migrator/IMigrator.cairo
@@ -18,6 +18,6 @@ namespace IMigrator {
     func value() -> (value: Uint256) {
     }
 
-    func migrate(tokenId: Uint256) -> (newTokenId: Uint256) {
+    func migrate(tokenIds_len: felt, tokenIds: Uint256*) -> (newTokenId: Uint256) {
     }
 }

--- a/src/migrator/presets/Migrator.cairo
+++ b/src/migrator/presets/Migrator.cairo
@@ -56,9 +56,9 @@ func value{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() ->
 //
 
 @external
-func migrate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(tokenId: Uint256) -> (
-    newTokenId: Uint256
-) {
-    let (new_token_id) = Migrator.migrate(token_id=tokenId);
+func migrate{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenIds_len: felt, tokenIds: Uint256*
+) -> (newTokenId: Uint256) {
+    let (new_token_id) = Migrator.migrate(token_ids_len=tokenIds_len, token_ids=tokenIds);
     return (newTokenId=new_token_id);
 }


### PR DESCRIPTION
closes #3
Points to discuss:
- This version emits an event for each token migrated. Another possibility is to change the event signature to handle arrays.
- No checks are made on the array length.